### PR TITLE
Add API improvements for CLI/LLM clients

### DIFF
--- a/docs/api/pages.md
+++ b/docs/api/pages.md
@@ -34,6 +34,8 @@ GET /pages/
 | `parent` | int | Direct children of this page ID |
 | `descendant_of` | int | All descendants of this page ID |
 | `status` | string | `draft`, `live`, or `live+draft` |
+| `slug` | string | Exact slug match (may return multiple if slug exists under different parents) |
+| `path` | string | Exact URL path match, e.g. `/blog/my-post/` (always 0 or 1 result) |
 | `search` | string | Full-text search |
 | `order` | string | Sort field, e.g. `title` or `-first_published_at` |
 | `offset` | int | Pagination offset (default: 0) |
@@ -155,10 +157,20 @@ Content-Type: application/json
 }
 ```
 
+The `parent` field also accepts a URL path string, which the server resolves to a page ID:
+
+```json
+{
+  "type": "blog.BlogPage",
+  "parent": "/blog/",
+  "title": "My New Post"
+}
+```
+
 | Field | Required | Description |
 |-------|----------|-------------|
 | `type` | Yes | Page type as `app_label.ModelName` |
-| `parent` | Yes | Parent page ID |
+| `parent` | Yes | Parent page ID (integer) or URL path (string, e.g. `"/blog/"`) |
 | `title` | Yes | Page title |
 | `slug` | No | Auto-generated from title if omitted |
 | `action` | No | Set to `"publish"` to publish immediately |

--- a/docs/api/schema-discovery.md
+++ b/docs/api/schema-discovery.md
@@ -50,7 +50,7 @@ The `allowed_parent_types` and `allowed_subpage_types` reflect the page model's 
 GET /schema/page-types/blog.BlogPage/
 ```
 
-Returns the full JSON Schema for the create, patch, and read schemas:
+Returns the full JSON Schema for the create, patch, and read schemas, plus detailed StreamField block definitions:
 
 ```json
 {
@@ -60,7 +60,7 @@ Returns the full JSON Schema for the create, patch, and read schemas:
     "type": "object",
     "properties": {
       "type": {"type": "string"},
-      "parent": {"type": "integer"},
+      "parent": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
       "title": {"type": "string"},
       "slug": {"anyOf": [{"type": "string"}, {"type": "null"}]},
       "published_date": {"anyOf": [{"type": "string", "format": "date"}, {"type": "null"}]},
@@ -70,11 +70,65 @@ Returns the full JSON Schema for the create, patch, and read schemas:
     "required": ["type", "parent", "title"]
   },
   "patch_schema": { ... },
-  "read_schema": { ... }
+  "read_schema": { ... },
+  "streamfield_blocks": {
+    "body": [
+      {
+        "type": "heading",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "text": {"type": "string", "required": true},
+            "size": {"type": "string", "enum": ["h2", "h3", "h4"], "required": true}
+          }
+        }
+      },
+      {
+        "type": "paragraph",
+        "schema": {"type": "richtext"}
+      },
+      {
+        "type": "image",
+        "schema": {"type": "image_chooser"}
+      },
+      {
+        "type": "gallery",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "image": {"type": "image_chooser", "required": true},
+              "caption": {"type": "string", "required": false}
+            }
+          }
+        }
+      }
+    ]
+  }
 }
 ```
 
-These schemas are the Pydantic models' JSON Schema representation, generated automatically from your Wagtail page models.
+The `create_schema`, `patch_schema`, and `read_schema` are Pydantic-generated JSON Schemas. The `streamfield_blocks` section provides detailed block type definitions for each StreamField on the model, including nested StructBlock properties, ListBlock item schemas, ChoiceBlock enums, and chooser block types. For page types with no StreamFields, `streamfield_blocks` is an empty object.
+
+### Block schema types
+
+| Schema type | Meaning |
+|-------------|---------|
+| `string` | CharBlock, TextBlock |
+| `richtext` | RichTextBlock (accepts HTML or Markdown) |
+| `integer` | IntegerBlock |
+| `float` | FloatBlock |
+| `boolean` | BooleanBlock |
+| `date` | DateBlock |
+| `datetime` | DateTimeBlock |
+| `url` | URLBlock |
+| `email` | EmailBlock |
+| `image_chooser` | ImageChooserBlock (value is an image ID) |
+| `page_chooser` | PageChooserBlock (value is a page ID) |
+| `object` | StructBlock (has `properties` with child block schemas) |
+| `array` | ListBlock (has `items` with the child block schema) |
+| `streamfield` | Nested StreamBlock (has `block_types` list) |
 
 ---
 

--- a/docs/guides/streamfield.md
+++ b/docs/guides/streamfield.md
@@ -97,7 +97,7 @@ StructBlock values are objects whose keys match the child block names:
 }
 ```
 
-The keys and types depend on the block definition in your Wagtail model. Use the [Schema Discovery API](../api/schema-discovery.md) to inspect the expected structure.
+The keys and types depend on the block definition in your Wagtail model. Use the [Schema Discovery API](../api/schema-discovery.md) to inspect the expected structure — the `streamfield_blocks` section of the schema response lists every block type, its value schema, and nested StructBlock/ListBlock definitions.
 
 ## ListBlock
 

--- a/src/wagtail_write_api/converters/rich_text.py
+++ b/src/wagtail_write_api/converters/rich_text.py
@@ -32,6 +32,7 @@ def convert_rich_text_input(value) -> str:
 
 def markdown_to_wagtail(md_text: str) -> str:
     """Convert Markdown to Wagtail's internal rich text format."""
+
     # Pre-process wagtail:// links before markdown conversion
     # Convert [text](wagtail://page/N) to placeholder that survives markdown
     def replace_wagtail_link(match):

--- a/src/wagtail_write_api/endpoints/pages.py
+++ b/src/wagtail_write_api/endpoints/pages.py
@@ -26,6 +26,8 @@ def list_pages(
     order: Optional[str] = None,
     offset: int = 0,
     limit: Optional[int] = None,
+    slug: Optional[str] = None,
+    path: Optional[str] = None,
 ):
     from wagtail.models import Page
 
@@ -60,6 +62,16 @@ def list_pages(
         qs = qs.filter(live=False)
     elif status == "live+draft":
         qs = qs.filter(live=True, has_unpublished_changes=True)
+
+    if slug:
+        qs = qs.filter(slug=slug)
+
+    if path:
+        resolved = _resolve_page_by_path(path)
+        if resolved:
+            qs = qs.filter(id=resolved.id)
+        else:
+            qs = qs.none()
 
     if search:
         qs = qs.search(search)
@@ -132,19 +144,33 @@ def create_page(request):
     except (json.JSONDecodeError, ValueError) as exc:
         return 422, {"error": "validation_error", "message": f"Invalid JSON: {exc}"}
     type_str = body.get("type")
-    parent_id = body.get("parent")
+    parent_ref = body.get("parent")
 
-    if not type_str or not parent_id:
+    if not type_str or not parent_ref:
         return 422, {"error": "validation_error", "message": "type and parent are required"}
 
     model_class = resolve_page_type(type_str)
     if not model_class:
         return 422, {"error": "validation_error", "message": f"Unknown page type: {type_str}"}
 
-    try:
-        parent_page = Page.objects.get(id=parent_id).specific
-    except Page.DoesNotExist:
-        return 422, {"error": "validation_error", "message": f"Parent page {parent_id} not found"}
+    # Resolve parent — accepts an integer ID or a URL path string
+    if isinstance(parent_ref, str) and not parent_ref.isdigit():
+        parent_page = _resolve_page_by_path(parent_ref)
+        if not parent_page:
+            return 422, {
+                "error": "validation_error",
+                "message": f"No page found at path: {parent_ref}",
+            }
+        parent_page = parent_page.specific
+    else:
+        parent_id = int(parent_ref)
+        try:
+            parent_page = Page.objects.get(id=parent_id).specific
+        except Page.DoesNotExist:
+            return 422, {
+                "error": "validation_error",
+                "message": f"Parent page {parent_id} not found",
+            }
 
     # Check parent allows this child type
     allowed = parent_page.specific_class.allowed_subpage_models()
@@ -395,6 +421,28 @@ def move_page(request, page_id: int):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+def _resolve_page_by_path(path: str):
+    """Resolve a URL path like '/blog/' to a Page, using the default Site's routing."""
+    from wagtail.models import Site
+
+    # Normalise: ensure leading and trailing slashes
+    path = path.strip()
+    if not path.startswith("/"):
+        path = "/" + path
+    if not path.endswith("/"):
+        path = path + "/"
+
+    site = Site.objects.filter(is_default_site=True).first()
+    if not site:
+        return None
+
+    try:
+        page, _, _ = site.root_page.specific.route(None, [c for c in path.split("/") if c])
+        return page
+    except Exception:
+        return None
+
+
 def _apply_fields(page, body, model_class):
     """Apply request body fields to a page instance."""
     from modelcluster.fields import ParentalKey

--- a/src/wagtail_write_api/endpoints/pages.py
+++ b/src/wagtail_write_api/endpoints/pages.py
@@ -153,6 +153,13 @@ def create_page(request):
     if not model_class:
         return 422, {"error": "validation_error", "message": f"Unknown page type: {type_str}"}
 
+    if isinstance(parent_ref, str):
+        parent_ref = parent_ref.strip()
+        if not parent_ref:
+            return 422, {
+                "error": "validation_error",
+                "message": "type and parent are required",
+            }
     # Resolve parent — accepts an integer ID or a URL path string
     if isinstance(parent_ref, str) and not parent_ref.isdigit():
         parent_page = _resolve_page_by_path(parent_ref)

--- a/src/wagtail_write_api/endpoints/schema_discovery.py
+++ b/src/wagtail_write_api/endpoints/schema_discovery.py
@@ -124,7 +124,9 @@ def _describe_block(block):
         return {"type": "streamfield", "block_types": block_types}
 
     if isinstance(block, ChoiceBlock):
-        choices = [choice[0] for choice in block.field.choices if choice[0]]
+        choices = [
+            choice[0] for choice in block.field.choices if choice[0] not in (None, "")
+        ]
         return {"type": "string", "enum": choices}
 
     if isinstance(block, RichTextBlock):

--- a/src/wagtail_write_api/endpoints/schema_discovery.py
+++ b/src/wagtail_write_api/endpoints/schema_discovery.py
@@ -48,11 +48,15 @@ def get_page_type_schema(request, type_str: str):
 
         raise Http404(f"Unknown page type: {type_str}")
 
+    model_class = _resolve_model(type_str)
+    streamfield_meta = _get_streamfield_meta(model_class) if model_class else {}
+
     return {
         "type": type_str,
         "create_schema": create_schema.model_json_schema(),
         "patch_schema": patch_schema.model_json_schema(),
         "read_schema": read_schema.model_json_schema(),
+        "streamfield_blocks": streamfield_meta,
     }
 
 
@@ -64,3 +68,97 @@ def _resolve_model(type_str):
         return apps.get_model(app_label, model_name)
     except (ValueError, LookupError):
         return None
+
+
+def _get_streamfield_meta(model_class):
+    """Introspect StreamField definitions and return block type schemas."""
+    from wagtail.fields import StreamField
+
+    result = {}
+    for field in model_class._meta.get_fields():
+        if isinstance(field, StreamField):
+            stream_block = field.stream_block
+            block_types = []
+            for name, block in stream_block.child_blocks.items():
+                block_types.append({"type": name, "schema": _describe_block(block)})
+            result[field.name] = block_types
+    return result
+
+
+def _describe_block(block):
+    """Produce a JSON-serializable schema description for a Wagtail block."""
+    from wagtail.blocks import (
+        BooleanBlock,
+        CharBlock,
+        ChoiceBlock,
+        DateBlock,
+        DateTimeBlock,
+        EmailBlock,
+        FloatBlock,
+        IntegerBlock,
+        ListBlock,
+        PageChooserBlock,
+        RichTextBlock,
+        StreamBlock,
+        StructBlock,
+        TextBlock,
+        URLBlock,
+    )
+    from wagtail.images.blocks import ImageChooserBlock
+
+    if isinstance(block, StructBlock):
+        properties = {}
+        for child_name, child_block in block.child_blocks.items():
+            child_schema = _describe_block(child_block)
+            child_schema["required"] = getattr(child_block.meta, "required", True)
+            properties[child_name] = child_schema
+        return {"type": "object", "properties": properties}
+
+    if isinstance(block, ListBlock):
+        return {"type": "array", "items": _describe_block(block.child_block)}
+
+    if isinstance(block, StreamBlock):
+        block_types = []
+        for name, child_block in block.child_blocks.items():
+            block_types.append({"type": name, "schema": _describe_block(child_block)})
+        return {"type": "streamfield", "block_types": block_types}
+
+    if isinstance(block, ChoiceBlock):
+        choices = [choice[0] for choice in block.field.choices if choice[0]]
+        return {"type": "string", "enum": choices}
+
+    if isinstance(block, RichTextBlock):
+        return {"type": "richtext"}
+
+    if isinstance(block, ImageChooserBlock):
+        return {"type": "image_chooser"}
+
+    if isinstance(block, PageChooserBlock):
+        return {"type": "page_chooser"}
+
+    if isinstance(block, BooleanBlock):
+        return {"type": "boolean"}
+
+    if isinstance(block, IntegerBlock):
+        return {"type": "integer"}
+
+    if isinstance(block, FloatBlock):
+        return {"type": "float"}
+
+    if isinstance(block, (DateTimeBlock,)):
+        return {"type": "datetime"}
+
+    if isinstance(block, (DateBlock,)):
+        return {"type": "date"}
+
+    if isinstance(block, URLBlock):
+        return {"type": "url"}
+
+    if isinstance(block, EmailBlock):
+        return {"type": "email"}
+
+    if isinstance(block, (CharBlock, TextBlock)):
+        return {"type": "string"}
+
+    # Fallback for unknown block types
+    return {"type": block.__class__.__name__}

--- a/src/wagtail_write_api/schema/generator.py
+++ b/src/wagtail_write_api/schema/generator.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pydantic import create_model
 
@@ -59,7 +59,7 @@ def generate_schemas_for_model(model_class):
     # CreateSchema: type + parent required, no id, slug optional
     create_fields = {}
     create_fields["type"] = (str, ...)
-    create_fields["parent"] = (int, ...)
+    create_fields["parent"] = (Union[int, str], ...)
     create_fields["action"] = (Optional[str], None)
     for name, (python_type, default) in write_fields.items():
         if name == "slug":

--- a/tests/test_pages_read.py
+++ b/tests/test_pages_read.py
@@ -53,9 +53,7 @@ class TestListPages:
         assert response.status_code == 401
 
     def test_filter_by_type(self, api_client, auth_header, page_tree):
-        response = api_client.get(
-            "/api/write/v1/pages/?type=testapp.BlogPage", **auth_header
-        )
+        response = api_client.get("/api/write/v1/pages/?type=testapp.BlogPage", **auth_header)
         assert response.status_code == 200
         data = response.json()
         for item in data["items"]:
@@ -63,35 +61,27 @@ class TestListPages:
 
     def test_filter_by_parent(self, api_client, auth_header, page_tree):
         parent_id = page_tree["blog_index"].id
-        response = api_client.get(
-            f"/api/write/v1/pages/?parent={parent_id}", **auth_header
-        )
+        response = api_client.get(f"/api/write/v1/pages/?parent={parent_id}", **auth_header)
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 2  # blog1 and blog2
 
     def test_filter_by_status_live(self, api_client, auth_header, page_tree):
-        response = api_client.get(
-            "/api/write/v1/pages/?status=live", **auth_header
-        )
+        response = api_client.get("/api/write/v1/pages/?status=live", **auth_header)
         assert response.status_code == 200
         data = response.json()
         for item in data["items"]:
             assert item["meta"]["live"] is True
 
     def test_filter_by_status_draft(self, api_client, auth_header, page_tree):
-        response = api_client.get(
-            "/api/write/v1/pages/?status=draft", **auth_header
-        )
+        response = api_client.get("/api/write/v1/pages/?status=draft", **auth_header)
         assert response.status_code == 200
         data = response.json()
         for item in data["items"]:
             assert item["meta"]["live"] is False
 
     def test_pagination(self, api_client, auth_header, page_tree):
-        response = api_client.get(
-            "/api/write/v1/pages/?offset=0&limit=1", **auth_header
-        )
+        response = api_client.get("/api/write/v1/pages/?offset=0&limit=1", **auth_header)
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 1
@@ -139,9 +129,7 @@ class TestDetailPage:
         blog1.save_revision()
         # Don't publish — so live revision still has "First Post"
 
-        response = api_client.get(
-            f"/api/write/v1/pages/{blog1.id}/?version=live", **auth_header
-        )
+        response = api_client.get(f"/api/write/v1/pages/{blog1.id}/?version=live", **auth_header)
         data = response.json()
         assert data["title"] == "First Post"
 
@@ -154,3 +142,57 @@ class TestDetailPage:
         response = api_client.get(f"/api/write/v1/pages/{page_id}/", **auth_header)
         data = response.json()
         assert "published_date" in data
+
+
+@pytest.mark.django_db
+class TestFilterBySlug:
+    def test_filter_by_slug(self, api_client, auth_header, page_tree):
+        response = api_client.get("/api/write/v1/pages/?slug=first-post", **auth_header)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["slug"] == "first-post"
+
+    def test_filter_by_slug_no_match(self, api_client, auth_header, page_tree):
+        response = api_client.get("/api/write/v1/pages/?slug=nonexistent-slug", **auth_header)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 0
+
+    def test_filter_by_slug_combined_with_type(self, api_client, auth_header, page_tree):
+        response = api_client.get(
+            "/api/write/v1/pages/?slug=first-post&type=testapp.BlogPage", **auth_header
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["meta"]["type"] == "testapp.BlogPage"
+
+
+@pytest.mark.django_db
+class TestFilterByPath:
+    def test_filter_by_path(self, api_client, auth_header, page_tree):
+        response = api_client.get("/api/write/v1/pages/?path=/blog/first-post/", **auth_header)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["slug"] == "first-post"
+
+    def test_filter_by_path_no_trailing_slash(self, api_client, auth_header, page_tree):
+        response = api_client.get("/api/write/v1/pages/?path=/blog/first-post", **auth_header)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+
+    def test_filter_by_path_no_match(self, api_client, auth_header, page_tree):
+        response = api_client.get("/api/write/v1/pages/?path=/nonexistent/path/", **auth_header)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 0
+
+    def test_filter_by_path_root_level(self, api_client, auth_header, page_tree):
+        response = api_client.get("/api/write/v1/pages/?path=/simple/", **auth_header)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["slug"] == "simple"

--- a/tests/test_pages_workflow.py
+++ b/tests/test_pages_workflow.py
@@ -22,9 +22,7 @@ def live_page(home_page):
 @pytest.mark.django_db
 class TestPublish:
     def test_publish_draft_page(self, api_client, auth_header, draft_page):
-        response = api_client.post(
-            f"/api/write/v1/pages/{draft_page.id}/publish/", **auth_header
-        )
+        response = api_client.post(f"/api/write/v1/pages/{draft_page.id}/publish/", **auth_header)
         assert response.status_code == 200
         draft_page.refresh_from_db()
         assert draft_page.live is True
@@ -37,9 +35,7 @@ class TestPublish:
 @pytest.mark.django_db
 class TestUnpublish:
     def test_unpublish_live_page(self, api_client, auth_header, live_page):
-        response = api_client.post(
-            f"/api/write/v1/pages/{live_page.id}/unpublish/", **auth_header
-        )
+        response = api_client.post(f"/api/write/v1/pages/{live_page.id}/unpublish/", **auth_header)
         assert response.status_code == 200
         live_page.refresh_from_db()
         assert live_page.live is False
@@ -54,9 +50,7 @@ class TestRevisions:
         draft_page.title = "Rev 3"
         draft_page.save_revision()
 
-        response = api_client.get(
-            f"/api/write/v1/pages/{draft_page.id}/revisions/", **auth_header
-        )
+        response = api_client.get(f"/api/write/v1/pages/{draft_page.id}/revisions/", **auth_header)
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 3

--- a/tests/test_pages_write.py
+++ b/tests/test_pages_write.py
@@ -98,6 +98,55 @@ class TestCreatePage:
         assert len(data["authors"]) == 2
         assert data["authors"][0]["name"] == "Alice"
 
+    def test_create_with_parent_path(self, api_client, auth_header, home_page):
+        """Accept a URL path string for the parent field."""
+        response = api_client.post(
+            "/api/write/v1/pages/",
+            data=json.dumps({"type": "testapp.SimplePage", "parent": "/", "title": "Path Parent"}),
+            content_type="application/json",
+            **auth_header,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "Path Parent"
+        assert data["meta"]["parent_id"] == home_page.id
+
+    def test_create_with_nested_parent_path(self, api_client, auth_header, blog_tree):
+        """Accept a nested path like /blog/ for the parent field."""
+        response = api_client.post(
+            "/api/write/v1/pages/",
+            data=json.dumps(
+                {
+                    "type": "testapp.BlogPage",
+                    "parent": "/blog/",
+                    "title": "Path Nested",
+                }
+            ),
+            content_type="application/json",
+            **auth_header,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["meta"]["parent_id"] == blog_tree["blog_index"].id
+
+    def test_create_with_invalid_parent_path_returns_422(self, api_client, auth_header, home_page):
+        """A path that doesn't resolve returns 422."""
+        response = api_client.post(
+            "/api/write/v1/pages/",
+            data=json.dumps(
+                {
+                    "type": "testapp.SimplePage",
+                    "parent": "/nonexistent/path/",
+                    "title": "Bad Path",
+                }
+            ),
+            content_type="application/json",
+            **auth_header,
+        )
+        assert response.status_code == 422
+        data = response.json()
+        assert "No page found at path" in data["message"]
+
     def test_create_without_auth_returns_401(self, api_client, home_page):
         response = api_client.post(
             "/api/write/v1/pages/",
@@ -122,9 +171,7 @@ class TestCreatePage:
         )
         assert response.status_code == 422
 
-    def test_create_invalid_streamfield_data_returns_422(
-        self, api_client, auth_header, blog_tree
-    ):
+    def test_create_invalid_streamfield_data_returns_422(self, api_client, auth_header, blog_tree):
         """Passing a dict instead of a list for a StreamField returns 422, not 500."""
         response = api_client.post(
             "/api/write/v1/pages/",
@@ -212,9 +259,7 @@ class TestUpdatePage:
 @pytest.mark.django_db
 class TestDeletePage:
     def test_delete_page(self, api_client, auth_header, home_page):
-        page = home_page.add_child(
-            instance=SimplePage(title="To Delete", slug="to-delete")
-        )
+        page = home_page.add_child(instance=SimplePage(title="To Delete", slug="to-delete"))
         page.save_revision()
         page_id = page.id
 

--- a/tests/test_schema_generation.py
+++ b/tests/test_schema_generation.py
@@ -81,3 +81,106 @@ class TestSchemaGeneration:
         assert "testapp.BlogPage" in types
         assert "testapp.BlogIndexPage" in types
         assert "testapp.EventPage" in types
+
+    def test_create_schema_parent_accepts_int_or_str(self):
+        from wagtail_write_api.schema.registry import schema_registry
+
+        _, create_schema, _ = schema_registry.get_schemas("testapp.SimplePage")
+        schema = create_schema.model_json_schema()
+        parent_schema = schema["properties"]["parent"]
+        # Should accept both int and string (for path-based lookup)
+        assert "anyOf" in parent_schema
+        types = [s["type"] for s in parent_schema["anyOf"]]
+        assert "integer" in types
+        assert "string" in types
+
+
+@pytest.mark.django_db
+class TestSchemaDiscoveryEndpoint:
+    def test_streamfield_blocks_in_schema(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.BlogPage/", **auth_header
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "streamfield_blocks" in data
+        assert "body" in data["streamfield_blocks"]
+        block_types = data["streamfield_blocks"]["body"]
+        type_names = [bt["type"] for bt in block_types]
+        assert "heading" in type_names
+        assert "paragraph" in type_names
+        assert "image" in type_names
+        assert "gallery" in type_names
+        assert "related_pages" in type_names
+
+    def test_structblock_has_properties(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.BlogPage/", **auth_header
+        )
+        data = response.json()
+        heading_block = next(
+            bt for bt in data["streamfield_blocks"]["body"] if bt["type"] == "heading"
+        )
+        schema = heading_block["schema"]
+        assert schema["type"] == "object"
+        assert "text" in schema["properties"]
+        assert "size" in schema["properties"]
+        # ChoiceBlock should have enum
+        size_schema = schema["properties"]["size"]
+        assert "enum" in size_schema
+        assert "h2" in size_schema["enum"]
+
+    def test_listblock_has_items(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.BlogPage/", **auth_header
+        )
+        data = response.json()
+        gallery_block = next(
+            bt for bt in data["streamfield_blocks"]["body"] if bt["type"] == "gallery"
+        )
+        schema = gallery_block["schema"]
+        assert schema["type"] == "array"
+        assert schema["items"]["type"] == "object"
+        assert "image" in schema["items"]["properties"]
+        assert "caption" in schema["items"]["properties"]
+
+    def test_richtext_block_type(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.BlogPage/", **auth_header
+        )
+        data = response.json()
+        para_block = next(
+            bt for bt in data["streamfield_blocks"]["body"] if bt["type"] == "paragraph"
+        )
+        assert para_block["schema"]["type"] == "richtext"
+
+    def test_image_chooser_block_type(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.BlogPage/", **auth_header
+        )
+        data = response.json()
+        img_block = next(bt for bt in data["streamfield_blocks"]["body"] if bt["type"] == "image")
+        assert img_block["schema"]["type"] == "image_chooser"
+
+    def test_no_streamfields_returns_empty(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.SimplePage/", **auth_header
+        )
+        data = response.json()
+        assert data["streamfield_blocks"] == {}
+
+    def test_event_page_streamfield_blocks(self, api_client, auth_header):
+        response = api_client.get(
+            "/api/write/v1/schema/page-types/testapp.EventPage/", **auth_header
+        )
+        data = response.json()
+        block_types = data["streamfield_blocks"]["body"]
+        type_names = [bt["type"] for bt in block_types]
+        assert "text" in type_names
+        assert "map_embed" in type_names
+        # text is RichTextBlock
+        text_block = next(bt for bt in block_types if bt["type"] == "text")
+        assert text_block["schema"]["type"] == "richtext"
+        # map_embed is URLBlock
+        url_block = next(bt for bt in block_types if bt["type"] == "map_embed")
+        assert url_block["schema"]["type"] == "url"

--- a/tests/test_streamfield.py
+++ b/tests/test_streamfield.py
@@ -9,9 +9,7 @@ from testapp.models import BlogIndexPage, BlogPage
 
 @pytest.fixture
 def blog_with_streamfield(home_page):
-    blog_index = home_page.add_child(
-        instance=BlogIndexPage(title="Blog", slug="blog", intro="")
-    )
+    blog_index = home_page.add_child(instance=BlogIndexPage(title="Blog", slug="blog", intro=""))
     blog_index.save_revision().publish()
 
     blog = blog_index.add_child(
@@ -40,7 +38,9 @@ def blog_with_streamfield(home_page):
 
 @pytest.mark.django_db
 class TestStreamFieldRead:
-    def test_streamfield_returns_list_of_blocks(self, api_client, auth_header, blog_with_streamfield):
+    def test_streamfield_returns_list_of_blocks(
+        self, api_client, auth_header, blog_with_streamfield
+    ):
         response = api_client.get(
             f"/api/write/v1/pages/{blog_with_streamfield.id}/", **auth_header
         )
@@ -48,7 +48,9 @@ class TestStreamFieldRead:
         assert isinstance(data["body"], list)
         assert len(data["body"]) == 2
 
-    def test_streamfield_block_has_type_value_id(self, api_client, auth_header, blog_with_streamfield):
+    def test_streamfield_block_has_type_value_id(
+        self, api_client, auth_header, blog_with_streamfield
+    ):
         response = api_client.get(
             f"/api/write/v1/pages/{blog_with_streamfield.id}/", **auth_header
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-write-api"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "django-ninja" },


### PR DESCRIPTION
Three changes to reduce friction for programmatic clients:

1. Accept parent by URL path in POST /pages/ — clients can now pass
   "parent": "/blog/" instead of requiring a page ID lookup first.

2. Add slug and path query parameters to GET /pages/ — enables precise
   page lookup without fuzzy full-text search.

3. Include StreamField block type details in schema endpoint — the
   GET /schema/page-types/{type}/ response now includes a
   streamfield_blocks section with full block definitions (StructBlock
   properties, ListBlock items, ChoiceBlock enums, chooser types).

https://claude.ai/code/session_015EcHWVeQ1KMcMuygDXtyop